### PR TITLE
Bump mobiledoc-text-renderer to ~0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.7.3",
-    "mobiledoc-text-renderer": "^0.3.1"
+    "mobiledoc-text-renderer": "^0.4.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",


### PR DESCRIPTION
Looks like there have been a minor release of `mobiledoc-text-renderer` Ive updated to the latest. Let me know if you need anything else on the PR